### PR TITLE
Deployment fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func migrateDB(db *sql.DB) {
 	log.Println("Current schema version:", version)
 	err = m.Up()
 	if err != nil && err != migrate.ErrNoChange && err != migrate.ErrLocked {
-		log.Println("Error while migration:", err)
+		log.Panic("Error while migration:", err)
 	}
 	version, dirty, err = m.Version()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -83,8 +83,8 @@ func migrateDB(db *sql.DB) {
 	}
 	log.Println("Current schema version:", version)
 	err = m.Up()
-	if err != nil && err != migrate.ErrNoChange {
-		log.Panic("Error while migration:", err)
+	if err != nil && err != migrate.ErrNoChange && err != migrate.ErrLocked {
+		log.Println("Error while migration:", err)
 	}
 	version, dirty, err = m.Version()
 	if err != nil {


### PR DESCRIPTION
- To support multiple instances starting in parallel, ignore lock error while migration.