### PR TITLE
build: use Go 1.11 as docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM golang:1.9
+FROM golang:1.11
 
 # Copy the local package files to the container's workspace.
 ADD . /go/src/github.com/RealImage/QLedger


### PR DESCRIPTION
Go 1.9 isn't supported anymore. 