### PR TITLE
main: mention LEDGER_AUTH_TOKEN if it's left empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	// Assert authentication
 	authToken, ok := os.LookupEnv("LEDGER_AUTH_TOKEN")
 	if !ok || authToken == "" {
-		log.Fatal("Cannot start the server. Authentication token is not set!!")
+		log.Fatal("Cannot start the server. Authentication token is not set!! Please set LEDGER_AUTH_TOKEN")
 	}
 
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))


### PR DESCRIPTION
`LEDGER_AUTH_TOKEN` is required so we should mention it be name if left empty.